### PR TITLE
アプリケーションがスリープしないようにする

### DIFF
--- a/src/main/appengine/app.yaml
+++ b/src/main/appengine/app.yaml
@@ -1,3 +1,7 @@
 runtime: java11
+env: standard
+instance_class: F1
 env_variables:
   BOT_TOKEN: "dummy"
+automatic_scaling:
+  min_instances: 1


### PR DESCRIPTION
# 概要
リクエストが一定時間行われないとアプリケーションが停止、終了してしまっていた。
常に動作するよう最小インスタンス数を1に指定する。