### PR TITLE
自動スケーリングではなく手動スケーリングを使用する

### DIFF
--- a/src/main/appengine/app.yaml
+++ b/src/main/appengine/app.yaml
@@ -3,5 +3,6 @@ env: standard
 instance_class: F1
 env_variables:
   BOT_TOKEN: "dummy"
-automatic_scaling:
-  min_instances: 1
+manual_scaling:
+  instances: 1  # 常に稼働させるインスタンス数を1に設定
+  

--- a/src/main/appengine/app.yaml
+++ b/src/main/appengine/app.yaml
@@ -1,8 +1,7 @@
 runtime: java11
 env: standard
-instance_class: F1
+instance_class: B1
 env_variables:
   BOT_TOKEN: "dummy"
 manual_scaling:
   instances: 1  # 常に稼働させるインスタンス数を1に設定
-  


### PR DESCRIPTION
# 概要
min_instancesを1にしてもインスタンスのシャットダウンは避けられなかった。
インスタンス数を固定できる手動スケーリングを用いる。