### PR TITLE
インスタンスの常時稼働をやめる

### DIFF
--- a/src/main/appengine/app.yaml
+++ b/src/main/appengine/app.yaml
@@ -1,7 +1,7 @@
-runtime: java11
-env: standard
+_runtime: java11
 instance_class: B1
 env_variables:
   BOT_TOKEN: "dummy"
-manual_scaling:
-  instances: 1  # 常に稼働させるインスタンス数を1に設定
+basic_scaling:
+  max_instances: 1
+  idle_timeout: 20m


### PR DESCRIPTION
# 概要
常時1インスタンスで稼働させると日に100円以上かかることがわかった。
ボイスチャンネル接続中のみハートビートを送るようにするか、SpringアプリケーションをやめてイベントドリブンなコードとしてGAE以外にデプロイするのが望ましいが、面倒なので設定変更で逃げる。
20分間アイドル状態であればシャットダウンするようにする。たいていの場面は20分以内に読み上げさせる想定。