### PR TITLE
不在時に受け取ったメッセージを読み上げないようにする

### DIFF
--- a/src/main/appengine/app.yaml
+++ b/src/main/appengine/app.yaml
@@ -1,4 +1,4 @@
-_runtime: java11
+runtime: java11
 instance_class: B1
 env_variables:
   BOT_TOKEN: "dummy"

--- a/src/main/java/jln/hobby/discordttsbot/listener/TextToSpeechListener.java
+++ b/src/main/java/jln/hobby/discordttsbot/listener/TextToSpeechListener.java
@@ -8,6 +8,7 @@ import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
 import org.springframework.stereotype.Component;
 
+import java.time.OffsetDateTime;
 import java.util.Objects;
 
 import javax.annotation.Nonnull;
@@ -22,6 +23,7 @@ public class TextToSpeechListener extends ListenerAdapter {
     private final String disconnectCommand;
     private final VoiceChannelService voiceChannelService;
     private final CommandService commandService;
+    private OffsetDateTime joinTime;
 
     public TextToSpeechListener(
             TtsBotProperties properties,
@@ -31,6 +33,7 @@ public class TextToSpeechListener extends ListenerAdapter {
         this.disconnectCommand = properties.command.disconnect;
         this.voiceChannelService = voiceChannelService;
         this.commandService = commandService;
+        this.joinTime = OffsetDateTime.now();
     }
 
     @Override
@@ -42,10 +45,16 @@ public class TextToSpeechListener extends ListenerAdapter {
         String content = message.getContentRaw();
 
         if (Objects.equals(content, connectCommand)) {
+            joinTime = OffsetDateTime.now();
             voiceChannelService.connect(event);
             return;
         } else if (Objects.equals(content, disconnectCommand)) {
             voiceChannelService.disconnect(event);
+            return;
+        }
+
+        // Skip messages received while being absent
+        if (event.getMessage().getTimeCreated().isBefore(joinTime)) {
             return;
         }
 


### PR DESCRIPTION
# 概要
Bot入室時に前回入室以後に投稿されたメッセージを読み上げてしまう問題を解決する。
入出時刻を記録し、その時刻より後に受信したメッセージのみを読み上げるようにする。