### PR TITLE
無料枠の多いF1インスタンスクラスを使用する

### DIFF
--- a/src/main/appengine/app.yaml
+++ b/src/main/appengine/app.yaml
@@ -1,7 +1,4 @@
 runtime: java11
-instance_class: B1
+instance_class: F1
 env_variables:
   BOT_TOKEN: "dummy"
-basic_scaling:
-  max_instances: 1
-  idle_timeout: 20m


### PR DESCRIPTION
# 概要
GAEの無料枠はF1インスタンスで28時間、B1インスタンスで9時間と差があった。
常時稼働で費用を発生させないようF1インスタンスを使用する。
アイドル時シャットダウンの問題はCloud Schedulerで定期的にエンドポイントを叩いて解決することとする。